### PR TITLE
Merge multiple review comments into a single comment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,7 @@ export async function run(): Promise<void> {
         } else {
           const groups = await grouper.groupFilesForReview(updatedDiff)
           const sysPrompt = prompt.getCodeReviewSystemPrompt(lang)
+          let aggregatedMessages = "";
 
           for (const group of groups) {
             const diffToSend = group.join('')
@@ -83,7 +84,11 @@ export async function run(): Promise<void> {
               core.setFailed('[review]Response content is missing')
             }
 
-            await github.createGitHubComment(message)
+            aggregatedMessages += message + "\n\n---\n\n";
+          }
+
+          if (aggregatedMessages !== "") {
+            await github.createGitHubComment(aggregatedMessages)
           }
         }
         break


### PR DESCRIPTION
Related to #186

Implements the feature to merge multiple review comments into a single comment for GitHub pull requests.

- Modifies `src/main.ts` to aggregate all review feedback from different groups into a single comment before posting to GitHub. This is achieved by concatenating messages with a separator and posting the aggregated message as a single comment.
- Adjusts the logic in the `review` case of the `run` function to support the aggregation of messages. This includes initializing an empty string for aggregated messages, appending each message from the review process with separators, and ensuring the aggregated message is posted only if it's not empty.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ca-dp/code-butler/issues/186?shareId=86cb1a5d-6ffb-4937-a584-8a9785b53b04).